### PR TITLE
Bugfix: fixed handling of the first match for different tags

### DIFF
--- a/lib/xml/XMLFilterWriter.js
+++ b/lib/xml/XMLFilterWriter.js
@@ -69,10 +69,6 @@ export default class XMLFilterWriter extends XMLMatcher {
         return fs.createWriteStream(this.outputFilePath);
     }
 
-    get parsingTag () {
-        return 'product';
-    }
-
     /**
      * @param {Array<string>} [tags]
      * @param {import('#types').XMLTagFilter} [filter]
@@ -94,7 +90,7 @@ export default class XMLFilterWriter extends XMLMatcher {
             this.setMatchFilter(filter);
         }
 
-        this.parseByTags(...tags || this.parsingTag);
+        this.parseByTags(...tags);
 
         return this;
     }

--- a/lib/xml/XMLMatcher.js
+++ b/lib/xml/XMLMatcher.js
@@ -56,10 +56,13 @@ export default class XMLMatcher extends XMLParser {
         this.emitter.emit('end');
     }
 
-    onOpenMatchedTag () {
-        super.onOpenMatchedTag();
+    /**
+     * @param {string} tagName
+     */
+    onOpenMatchedTag (tagName) {
+        super.onOpenMatchedTag(tagName);
 
-        if (this.isFirstMatch()) {
+        if (this.isFirstMatch(tagName)) {
             this.onFirstMatch();
         }
     }

--- a/lib/xml/XMLParser.js
+++ b/lib/xml/XMLParser.js
@@ -19,9 +19,16 @@ export default class XMLParser {
         this.streamer.on('end', this.onEnd.bind(this));
         this.streamer.on('error', this.onError.bind(this));
 
-        this.matchesCount = 0;
+        /**
+         * @type {{ [tagName: string]: number }}
+         */
+        this.matchesCount = {};
         this.cache = '';
         this.emitter = new EventEmitter();
+    }
+
+    get totalMatchesCount() {
+        return Object.values(this.matchesCount).reduce((a, b) => a + b, 0);
     }
 
     /**
@@ -52,6 +59,10 @@ export default class XMLParser {
     
         this.matchedTags = matchedTags;
 
+        this.matchedTags.forEach(tagName => {
+            this.matchesCount[tagName] = 0;
+        });
+
         this.readFileStream = fs.createReadStream(this.filePath);
 
         this.readFileStream.pipe(this.streamer);
@@ -74,12 +85,15 @@ export default class XMLParser {
     onOpenTag (currentTag) {
         if (this.matchedTags && this.matchedTags.includes(currentTag.name)) {
             this.isMatchedTagOpen = true;
-            this.onOpenMatchedTag();
-            this.matchesCount++;
+            this.onOpenMatchedTag(currentTag.name);
+            this.matchesCount[currentTag.name]++;
         }
     }
 
-    onOpenMatchedTag () {
+    /**
+     * @param {string} _tagName 
+     */
+    onOpenMatchedTag (_tagName) {
         this.emitter.emit('openmatchedtag', this);
     }
 
@@ -96,13 +110,16 @@ export default class XMLParser {
     onCloseMatchedTag () {
         this.emitter.emit('closematchedtag', this);
 
-        if (this.matchesCount % 10000 === 0) {
-            log(`${this.name}${this.formattedFile} - Proceeded ${this.matchesCount / 1000}k matches`);
+        if (this.totalMatchesCount % 10000 === 0) {
+            log(`${this.name}${this.formattedFile} - Proceeded ${this.totalMatchesCount / 1000}k matches`);
         }
     }
 
-    isFirstMatch () {
-        return this.matchesCount === 0;
+    /**
+     * @param {string} tagName 
+     */
+    isFirstMatch (tagName) {
+        return this.matchesCount[tagName] === 0;
     }
 
     onEnd () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sfcc-catalog-reducer",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Module to make huge master catalog for SFCC platform smaller for dev/qa purpoes",
     "main": "index.js",
     "bin": {

--- a/testdata/priceBook/priceBook1.xml
+++ b/testdata/priceBook/priceBook1.xml
@@ -7,6 +7,9 @@
             <online-flag>true</online-flag>
         </header>
         <price-tables>
+            <price-table product-id="some-unused-product-that-will-be-filtered-out">
+                <amount quantity="1">0.00</amount>
+            </price-table>
             <price-table product-id="product-1">
                 <amount quantity="1">250.00</amount>
             </price-table>


### PR DESCRIPTION
The bug was causing missing `<price-tables>` open tag after reduce in case when the first `<price-table>` should be filtered out after reducing.

![image](https://user-images.githubusercontent.com/44097600/177565883-f3502f71-6cde-4996-a883-5eb6328254ff.png)
